### PR TITLE
Really fix twine install for wheels job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,9 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
+      - name: Install twine
+        run: |
+          python -m pip install twine
       - name: Publish to PyPi
         env:
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
@@ -57,9 +60,6 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./dist/mthree*
-      - name: Install twine
-        run: |
-          python -m pip install twine
       - name: Publish to PyPi
         env:
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}


### PR DESCRIPTION
In #26 we tried to fix the release wheels job which was missing a twine
install. However that PR was incorrect and added the new step to the
wrong job in the workflow. This commit corrects it so we actuall install
twine where it is needed.