### PR TITLE
Set version to 2.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,8 @@ import setuptools
 import numpy as np
 from Cython.Build import cythonize
 
-MAJOR = 3
-MINOR = 0
+MAJOR = 2
+MINOR = 8
 MICRO = 0
 
 ISRELEASED = True


### PR DESCRIPTION
To fix some issues with internal circuit paths we need another release before 3.0