### PR TITLE
Tweaks for BackendV1

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -193,4 +193,4 @@ is set too low.
 
 .. jupyter-execute::
 
-    quasis = mit.apply_correction(raw_counts, range(6), method='iterative', tol=1e-6)
+    quasis = mit.apply_correction(raw_counts, range(6), method='iterative', tol=1e-5)

--- a/mthree/_helpers.py
+++ b/mthree/_helpers.py
@@ -13,7 +13,7 @@
 """
 Helper functions
 """
-
+from qiskit.providers.backend import BackendV1
 
 def system_info(backend):
     """Return backend information needed by M3.
@@ -27,12 +27,16 @@ def system_info(backend):
     info_dict = {}
     info_dict["inoperable_qubits"] = []
     config = backend.configuration()
-    info_dict["name"] = backend.name
+    if isinstance(backend, BackendV1):
+        name = backend.name()
+    else:
+        name = backend.name
+    info_dict["name"] = name
     info_dict["num_qubits"] = config.num_qubits
     _max_shots = config.max_shots
     info_dict["max_shots"] = _max_shots if _max_shots else int(1e6)
     info_dict["simulator"] = config.simulator
-    if "fake" in backend.name:
+    if "fake" in info_dict["name"]:
         info_dict["simulator"] = True
     # max_circuits can be set a couple of ways
     max_circuits = getattr(config, "max_experiments", 1)

--- a/mthree/_helpers.py
+++ b/mthree/_helpers.py
@@ -15,6 +15,7 @@ Helper functions
 """
 from qiskit.providers.backend import BackendV1
 
+
 def system_info(backend):
     """Return backend information needed by M3.
 

--- a/mthree/mitigation.py
+++ b/mthree/mitigation.py
@@ -439,7 +439,7 @@ class M3Mitigation:
         distance=None,
         method="auto",
         max_iter=25,
-        tol=1e-3,
+        tol=1e-4,
         return_mitigation_overhead=False,
         details=False,
     ):
@@ -451,7 +451,7 @@ class M3Mitigation:
             distance (int): Distance to correct for. Default=num_bits
             method (str): Solution method: 'auto', 'direct' or 'iterative'.
             max_iter (int): Max. number of iterations, Default=25.
-            tol (float): Convergence tolerance of iterative method, Default=1e-3.
+            tol (float): Convergence tolerance of iterative method, Default=1e-4.
             return_mitigation_overhead (bool): Returns the mitigation overhead, default=False.
             details (bool): Return extra info, default=False.
 


### PR DESCRIPTION
Fixes issues with `BackendV1` support

- Also take the opportunity to tweak the tolerance to 1e4 as that seems to be the sweet spot.