### PR TITLE
update release.yml back to tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,8 @@
 name: Release Artifacts
 on:
   push:
-    branches: [2.8]
+    tags:
+      - '*'
 
 jobs:
   build_wheels:


### PR DESCRIPTION
Now that the release.yml is working again, make it trigger on release tags only again.