### PR TITLE
Do not use runtime mode implicitly

### DIFF
--- a/docs/runtime.rst
+++ b/docs/runtime.rst
@@ -21,4 +21,4 @@ in `mthree.M3Mitigation.cals_from_system`.  For example:
     mit.cals_from_system(runtime_mode=batch); # This is where the Batch or Session goes
 
 
-Note that if no `runtime_mode` is set, and the passed system is an IBM backend, then jobs are submitted in `Batch` mode automatically.  This mode is NOT closed by default, allowing users to include additional jobs.  This mode can be accessed via `mode = mit.system.get_mode()`
+Note that if no `runtime_mode` is set, and the passed system is an IBM backend, then jobs are submitted in `Job` mode, i.e. independently, by default.

--- a/mthree/mitigation.py
+++ b/mthree/mitigation.py
@@ -165,9 +165,7 @@ class M3Mitigation:
 
         if isinstance(self.system, rm.RunningManBackend):
             if runtime_mode:
-                self.system.set_mode(runtime_mode, overwrite=True)
-            elif not self.system.get_mode():
-                self.system.set_mode("batch")
+                self.system.set_mode(runtime_mode)
         if qubits is None:
             qubits = range(self.num_qubits)
             # Remove faulty qubits if any


### PR DESCRIPTION
In the last release jobs would be batched automatically if no runtime mode was given.  This undoes that, and makes using Batch or Session explicit.