### PR TITLE
Add fast-math to compiler flags

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,7 @@ if sys.platform == "win32" and os.environ.get("MSYSTEM", None) is None:
 else:
     COMPILER_FLAGS = [
         "-O3",
+        "-ffast-math",
         "-std=c++17",
         "-DNPY_NO_DEPRECATED_API=NPY_1_23_API_VERSION",
     ]


### PR DESCRIPTION
This vectorizes the last loop in the main path that was blocked by


./elements.h:66:22: remark: loop not vectorized: cannot prove it is safe to reorder floating-point operations; allow reordering by specifying '#pragma clang loop vectorize(enable)' before the loop or by providing the compiler option '-ffast-math'. [-Rpass-analysis=loop-vectorize]

closes #259 