### PR TITLE
Remove reference to `BackendV1` for compatibility with Qiskit 2.0

### DIFF
--- a/mthree/_helpers.py
+++ b/mthree/_helpers.py
@@ -27,7 +27,10 @@ def system_info(backend):
     info_dict = {}
     info_dict["inoperable_qubits"] = []
     config = backend.configuration()
-    name = backend.name
+    if backend.version == 1:
+        name = backend.name()
+    else:
+        name = backend.name
     info_dict["name"] = name
     info_dict["num_qubits"] = config.num_qubits
     _max_shots = config.max_shots

--- a/mthree/_helpers.py
+++ b/mthree/_helpers.py
@@ -19,7 +19,7 @@ def system_info(backend):
     """Return backend information needed by M3.
 
     Parameters:
-        backend (BackendV2): A Qiskit backend
+        backend (BackendV1 or BackendV2): A Qiskit backend
 
     Returns:
         dict: Backend information

--- a/mthree/_helpers.py
+++ b/mthree/_helpers.py
@@ -13,14 +13,13 @@
 """
 Helper functions
 """
-from qiskit.providers.backend import BackendV1
 
 
 def system_info(backend):
     """Return backend information needed by M3.
 
     Parameters:
-        backend (BackendV1 or BackendV2): A Qiskit backend
+        backend (BackendV2): A Qiskit backend
 
     Returns:
         dict: Backend information
@@ -28,10 +27,7 @@ def system_info(backend):
     info_dict = {}
     info_dict["inoperable_qubits"] = []
     config = backend.configuration()
-    if isinstance(backend, BackendV1):
-        name = backend.name()
-    else:
-        name = backend.name
+    name = backend.name
     info_dict["name"] = name
     info_dict["num_qubits"] = config.num_qubits
     _max_shots = config.max_shots

--- a/mthree/generators/__init__.py
+++ b/mthree/generators/__init__.py
@@ -10,7 +10,6 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Generators
-"""
+"""Generators"""
 
 from .hadamard import HadamardGenerator

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,7 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""M3: Matrix-free measurement mitigation
-"""
+"""M3: Matrix-free measurement mitigation"""
 
 import os
 import sys


### PR DESCRIPTION
With this removed reference to `BackendV1`, all test pass with `qiskit==2.0.0rc2`.

A release must be tagged with this (or a similar) change before March 31 for users to be able to use mthree with Qiskit 2.0.

If we have reason to suspect that users are still using `BackendV1` devices with mthree, then we could do one of two things:
- Bump the required qiskit version in `requirements.txt` to `qiskit>=2.0.0`.  That way, people on Qiskit 1.x will continue to use old versions of mthree with `BackendV1` support
- modify this PR so that it fails silently if `BackendV1` cannot be imported, but tests `isinstance` if it is available.

I prefer the first option since it emphasizes the future over the past.

UPDATE: this PR has now been modified to do the second option, using the `backend.version` attribute.