### PR TITLE
update release workflow to add aarch64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,11 +21,13 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.16.5
         env:
-          CIBW_SKIP: "cp36-* cp37-* cp38-* pp* *musl*"
+          CIBW_SKIP: "cp36-* cp37-* cp38-* pp* *musl* *i686"
           CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64 *-win32 *-win_amd64 *-manylinux_i686 cp310-manylinux*"
-          CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2014_x86_64:latest
-          CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux2014_i686:latest
-          CIBW_ARCHS_MACOS: x86_64 universal2
+          CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypamanylinux_2_34_x86_64:latest
+          CIBW_MANYLINUX_AARCH64_IMAGE: quay.io/pypa/manylinux_2_34_aarch64:latest
+          CIBW_ARCHS_LINUX: x86_64 aarch64
+          CIBW_ARCHS_WINDOWS: AMD64
+          CIBW_ARCHS_MACOS: x86_64 universal2 arm64
           CIBW_TEST_REQUIRES: pytest qiskit-aer setuptools
           CIBW_TEST_COMMAND_LINUX: pytest -p no:warnings /mthree_test
           CIBW_TEST_COMMAND_WINDOWS: pytest -p no:warnings C:\Users\RUNNER~1\AppData\Local\Temp\mthree_test


### PR DESCRIPTION
Adds `aarch64` builds for Linux, and drops `i686` builds.

closes #269
