### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ expval, stddev = quasi.expval_and_stddev()
 The results of M3 mitigation are quasi-probabilities that nominally contain small negative values.
 This is suitable for use in computing corrected expectation values or sampling problems
 where one is interested in the highest probability bit-string.  However, if one needs
-a true probability distribution then it is possible to convert from quasi-probabilites to
+a true probability distribution then it is possible to convert from quasi-probabilities to
 the closest true probability distribution in L2-norm using:
 
 ```python

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -11,7 +11,7 @@ Options for M3Mitigation class
 ~~~~~~~~~~~~~~~~~~
 
 The main :class:`mthree.M3Mitigation` class accepts the `iter_threshold` keyword argument
-that determines when the automated method selector pickes the iterative method 
+that determines when the automated method selector picks the iterative method 
 over direct LU factorization (selection also depends on free memory).
 
 .. jupyter-execute::
@@ -52,7 +52,7 @@ balanced bit-strings over four qubits are:
     list(gen)
 
 The ``independent`` method also sends :math:`2N` circuits but measures only a single qubit at a time.
-As such, this is a truely uncorrelated calibration process.
+As such, this is a truly uncorrelated calibration process.
 
 Finally, a ``marginal`` calibration can also be done that sends only two circuits,
 :math:`|0\rangle^{\otimes N}` and :math:`|1\rangle^{\otimes N}`, and marginalizes over the
@@ -94,7 +94,7 @@ option.
     Do not set this unless you know what you are doing.
 
 A boolean value that specifies whether reset instructions should be used at the beginning of the
-calibration circuits.  Ideally this helps to supress any residual state prep errors that occur from
+calibration circuits.  Ideally this helps to suppress any residual state prep errors that occur from
 imperfect reset of the qubits.  Can be used in concert with, or as an alternative to ``rep_delay``.
 Note that, in order for this to work, the circuits that need to be mitigated must also have reset
 instructions at the beginning.  Otherwise you are calibrating for no state-prep errors, but the
@@ -145,8 +145,8 @@ can simply set the option:
 
 ``distance``
 ~~~~~~~~~~~~
-Optionally one may trucate the M3 assignment matrix to only those elements of the matrix that
-are transistions between elements less than or equal to a given Hamming distance away from
+Optionally one may truncate the M3 assignment matrix to only those elements of the matrix that
+are transitions between elements less than or equal to a given Hamming distance away from
 each other.  This does not change the dimensionality of the underlying matrix, but rather
 changes the sparsity pattern of the elements.  This is done using the ``distance`` keyword argument.
 By default, M3 computes the corrections out to the full distance.  In practice, including only

--- a/docs/balanced.rst
+++ b/docs/balanced.rst
@@ -26,7 +26,7 @@ similarly for the `1` element.  So when we execute the balanced calibration circ
 using `shots` number of samples, each error rate in the calibration data is actually
 being sampled more times than requested.  Thus, when you pass the `shots` value to M3, in the balanced
 calibration mode internally it divides by the number of measured qubits so that the precision of each
-error rate matches the precison of the other methods.  That is to say that the following:
+error rate matches the precision of the other methods.  That is to say that the following:
 
  .. jupyter-execute::
 
@@ -36,7 +36,7 @@ error rate matches the precison of the other methods.  That is to say that the f
     mit = mthree.M3Mitigation(backend)
     mit.cals_from_system(method='balanced')
 
-Will sample each indepdendent qubit error rate `10000` times (or the max allowed by the target system if less) 
+Will sample each independent qubit error rate `10000` times (or the max allowed by the target system if less) 
 regardless of which method is used. All pair-wise correlations are measured half this number of times. This
 yields a calibration process whose  overhead is independent of the number of qubits used; there is no additional
 cost to compute the calibration over a full device.  Note that, when using a simulator or "fake" device, 

--- a/docs/error.rst
+++ b/docs/error.rst
@@ -4,7 +4,7 @@
 Error analysis
 ##############
 
-Mitigating readout errors does not come for free.  Instead, there is an overhaed that
+Mitigating readout errors does not come for free.  Instead, there is an overhead that
 results in increased uncertainty in the computed results.  M3 will optionally compute this
 overhead and return an upper-bound on the expected standard deviation (variance) of the
 computed expectation values.
@@ -42,14 +42,14 @@ Let us first calibrate the mitigator and get raw results:
     raw_counts = backend.run(trans_qc, shots=8192).result().get_counts()
 
 
-In order to compute the standard deviation of out mitigated expectation values
+In order to compute the standard deviation of our mitigated expectation values
 we need to request the information be computed:
 
 .. jupyter-execute::
 
     quasis = mit.apply_correction(raw_counts, range(6), return_mitigation_overhead=True)
 
-The mitigation overhead is returned as an attribute of the returned quasi-probabilites
+The mitigation overhead is returned as an attribute of the returned quasi-probabilities
 
 .. jupyter-execute::
 
@@ -69,4 +69,4 @@ It is also possible to return both the expectation value and standard deviation 
     quasis.expval_and_stddev()
 
 Although this standard deviation is an upper-bound, it is usually a tight upper-bound that can be
-faithfully used futher analysis.
+faithfully used further analysis.

--- a/docs/expvals.rst
+++ b/docs/expvals.rst
@@ -47,7 +47,7 @@ a noisy-simulator.
     quasi3 = mit.apply_correction(raw3, [0,1,2], return_mitigation_overhead=True)
 
 
-Now let us compute the expectaion values of these distributions for the default
+Now let us compute the expectation values of these distributions for the default
 case of ``Z`` operators on each qubit:
 
 .. jupyter-execute::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,12 +15,12 @@ of equations is nominally much easier to solve.
     :align: center
 
 It is often the case that this linear equation is trivial to solve using LU decomposition,
-using only modest computing resources.  However, if the number of unique bistrings is large,
+using only modest computing resources.  However, if the number of unique bitstrings is large,
 and / or one has very tight memory constraints, then the problem can be solved in a matrix-free
 manner using a preconditioned iterative linear solution method, e.g. the Generalized minimal
 residual (GMRES) or biconjugate gradient stabilized (BiCGSTAB) methods.
 
-M3 is suitable for problems ameanable to using quasi-probabilities such as those
+M3 is suitable for problems amenable to using quasi-probabilities such as those
 formulated in terms of expectation values, or sampling problems where, for example, one is
 interested in the bit-string with the highest probability.  Quasi-probabilities can be
 projected onto the nearest probability distribution if true probabilities are desired, but

--- a/docs/marginals.rst
+++ b/docs/marginals.rst
@@ -6,7 +6,7 @@ Low-weight observables (Marginals)
 
 Often one is interested in computing expectation values of "low-weight" observables, where
 the operator is comprised of one or more identity operators, e.g. :math:`\langle IIZZII\rangle`.
-Qubits with an idenitiy do not need to be corrected because the eigenvalues associated with the
+Qubits with an identity do not need to be corrected because the eigenvalues associated with the
 :math:`|0\rangle` and :math:`|1\rangle` states are the same.  Because M3 scales with the number of
 bit-strings, removing these unneeded elements can reduce the amount of computation required. Below
 is an example of how to use M3 to marginalize and correct over the smaller distribution.

--- a/docs/probs.rst
+++ b/docs/probs.rst
@@ -1,7 +1,7 @@
 .. _probs:
 
 ##########################
-Converting to probabilites
+Converting to probabilities
 ##########################
 
 M3 natively works with quasi-probability distributions; distributions that contain negative values

--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -62,7 +62,7 @@ computing things like expectation values.  So M3 includes the generic functions
 :func:`mthree.utils.expval_and_stddev` that operate on the native
 ``Counts`` objects in Qiskit.
 
-For example let us compare raw data verse the mitigated results in a simple case.
+For example let us compare raw data versus the mitigated results in a simple case.
 
 .. jupyter-execute::
 

--- a/mthree/direct.py
+++ b/mthree/direct.py
@@ -66,7 +66,7 @@ def direct_solver(
         return_mitigation_overhead (bool): Returns the mitigation overhead, default=False.
 
     Returns:
-        QuasiDistribution: dict of Quasiprobabilites
+        QuasiDistribution: dict of QuasiProbabilities
     """
     cals = mitigator._form_cals(qubits)
     num_bits = len(qubits)

--- a/mthree/direct.py
+++ b/mthree/direct.py
@@ -66,7 +66,7 @@ def direct_solver(
         return_mitigation_overhead (bool): Returns the mitigation overhead, default=False.
 
     Returns:
-        QuasiDistribution: dict of QuasiProbabilities
+        QuasiDistribution: dict of Quasiprobabilities
     """
     cals = mitigator._form_cals(qubits)
     num_bits = len(qubits)

--- a/mthree/iterative.py
+++ b/mthree/iterative.py
@@ -48,7 +48,7 @@ def iterative_solver(
         return_mitigation_overhead (bool): Returns the mitigation overhead, default=False.
 
     Returns:
-        QuasiDistribution: dict of Quasiprobabilites
+        QuasiDistribution: dict of Quasiprobabilities
 
     Raises:
         M3Error: Solver did not converge.

--- a/mthree/mitigation.py
+++ b/mthree/mitigation.py
@@ -267,7 +267,7 @@ class M3Mitigation:
     def cals_from_matrices(self, matrices):
         """Init calibration data from list of NumPy arrays.
 
-        Missing entires are set to None elements.
+        Missing entries are set to None elements.
 
         Parameters:
             matrices (list_like): List of cals as NumPy arrays

--- a/mthree/test/column_testing.pyx
+++ b/mthree/test/column_testing.pyx
@@ -37,13 +37,13 @@ def _test_vector_column_norm(object counts,
     cdef map[string, float] counts_map = counts
     cdef unsigned int num_elems = counts_map.size()
 
-    # Assign memeory for bitstrings and input probabilities
+    # Assign memory for bitstrings and input probabilities
     cdef unsigned char * bitstrings = <unsigned char *>malloc(num_bits*num_elems*sizeof(unsigned char))
     cdef float * input_probs = <float *>malloc(num_elems*sizeof(float))
-    # Assign memeory for column norms
+    # Assign memory for column norms
     cdef float[::1] col_norms = np.zeros(num_elems, dtype=np.float32)
 
-    # Convert sorted counts dict into bistrings and input probability arrays
+    # Convert sorted counts dict into bitstrings and input probability arrays
     counts_to_internal(&counts_map, bitstrings, input_probs, num_bits, shots)
     # Compute column norms
     compute_col_norms(&col_norms[0], bitstrings, &cals[0], num_bits, num_elems, distance)

--- a/mthree/test/converters_testing.pyx
+++ b/mthree/test/converters_testing.pyx
@@ -28,11 +28,11 @@ def _test_counts_to_array(object counts):
     cdef size_t kk, ll
     cdef list out
     
-    # Assign memeory for bitstrings and input probabilities
+    # Assign memory for bitstrings and input probabilities
     cdef unsigned char * bitstrings = <unsigned char *>malloc(num_bits*num_elems*sizeof(unsigned char))
     cdef float * input_probs = <float *>malloc(num_elems*sizeof(float))
 
-    # Convert sorted counts dict into bistrings and input probability arrays
+    # Convert sorted counts dict into bitstrings and input probability arrays
     counts_to_internal(&counts_map, bitstrings, input_probs, num_bits, shots)
 
     out = ['']*num_elems
@@ -55,11 +55,11 @@ def _test_counts_roundtrip(object counts):
     cdef unsigned int num_elems = counts_map.size()
     cdef size_t kk, ll
     
-    # Assign memeory for bitstrings and input probabilities
+    # Assign memory for bitstrings and input probabilities
     cdef unsigned char * bitstrings = <unsigned char *>malloc(num_bits*num_elems*sizeof(unsigned char))
     cdef float * input_probs = <float *>malloc(num_elems*sizeof(float))
 
-    # Convert sorted counts dict into bistrings and input probability arrays
+    # Convert sorted counts dict into bitstrings and input probability arrays
     counts_to_internal(&counts_map, bitstrings, input_probs, num_bits, shots)
     internal_to_probs(&counts_map, input_probs)
     cdef dict out = counts_map

--- a/mthree/test/test_extra_cals.py
+++ b/mthree/test/test_extra_cals.py
@@ -22,7 +22,7 @@ import mthree
 
 
 def test_missing_qubit_cal():
-    """Test if missing calibration is retrived at apply_correcton."""
+    """Test if missing calibration is retrieved at apply_correction."""
 
     qc = QuantumCircuit(5)
     qc.h(2)

--- a/mthree/test/test_full.py
+++ b/mthree/test/test_full.py
@@ -69,7 +69,7 @@ def vector_to_probs(vec, counts):
     """Return dict of probabilities.
 
     Parameters:
-        vec (ndarray): 1d vector of probabilites.
+        vec (ndarray): 1d vector of probabilities.
         counts (dict): Dict of counts
 
     Returns:

--- a/mthree/test/test_grouping.py
+++ b/mthree/test/test_grouping.py
@@ -11,7 +11,7 @@
 # that they have been altered from the originals.
 # pylint: disable=no-name-in-module
 
-"""Test opertor groupings"""
+"""Test operator groupings"""
 import numpy as np
 from qiskit import QuantumCircuit, transpile
 from qiskit_ibm_runtime.fake_provider import FakeAthensV2 as FakeAthens

--- a/mthree/test/test_reduced_matrix.py
+++ b/mthree/test/test_reduced_matrix.py
@@ -56,7 +56,7 @@ def vector_to_probs(vec, counts):
     """Return dict of probabilities.
 
     Parameters:
-        vec (ndarray): 1d vector of probabilites.
+        vec (ndarray): 1d vector of probabilities.
         counts (dict): Dict of counts
 
     Returns:

--- a/mthree/utils.py
+++ b/mthree/utils.py
@@ -333,7 +333,7 @@ def vector_to_quasiprobs(vec, counts):
     """Return dict of quasi-probabilities.
 
     Parameters:
-        vec (ndarray): 1d vector of quasi-probabilites.
+        vec (ndarray): 1d vector of quasi-probabilities.
         counts (dict): Dict of counts
 
     Returns:

--- a/setup.py
+++ b/setup.py
@@ -144,7 +144,7 @@ openmp = %(with_omp)s
 local_path = os.path.dirname(os.path.abspath(sys.argv[0]))
 os.chdir(local_path)
 sys.path.insert(0, local_path)
-sys.path.insert(0, os.path.join(local_path, "mthree"))  # to retrive _version
+sys.path.insert(0, os.path.join(local_path, "mthree"))  # to retrieve _version
 
 # always rewrite _version
 if os.path.exists("mthree/version.py"):

--- a/tutorials/03_qv_example.ipynb
+++ b/tutorials/03_qv_example.ipynb
@@ -117,12 +117,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "87e116f2",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Add meauserements to circuits and transpile\n",
+    "# Add measurements to circuits and transpile\n",
     "trans_circs = transpile([circ.measure_all(inplace=False) for circ in qv_circs], noisy_sim,\n",
     "                        layout_method='sabre', routing_method='sabre', optimization_level=3)"
    ]

--- a/tutorials/04_dynamic_bv.ipynb
+++ b/tutorials/04_dynamic_bv.ipynb
@@ -218,7 +218,7 @@
    "source": [
     "## Run experiment and mitigate\n",
     "\n",
-    "Here we execute the dynamic BV ciruits at 10,000 shots each."
+    "Here we execute the dynamic BV circuits at 10,000 shots each."
    ]
   },
   {
@@ -237,7 +237,7 @@
    "id": "82097098",
    "metadata": {},
    "source": [
-    "Next we follow the usual M3 receipe to mitigate the counts.  Note that the `mappings`\n",
+    "Next we follow the usual M3 recipe to mitigate the counts.  Note that the `mappings`\n",
     "have all the necessary information for correcting mid-circuit measurements."
    ]
   },


### PR DESCRIPTION
### Fix typos
- probabilites -> probabilities
- pickes -> picks
- truely -> truly
- supress -> suppress
- trucate -> truncate
- transistions -> transitions
- precison -> precision
- indepdendent -> independent
- overhaed -> overhead
- futher -> further
- expectaion -> expectation
- bistrings -> bitstrings
- ameanable -> amenable
- idenitiy -> identity
- verse -> versus
- Quasiprobabilites -> Quasiprobabilities
- entires -> entries
- memeory -> memory
- retrived -> retrieved
- opertor -> operator
- meauserements -> measurements
- ciruits -> circuits
- receipe -> recipe